### PR TITLE
HotFix - Temporarily increases the number of categories per menu.

### DIFF
--- a/menus/views.py
+++ b/menus/views.py
@@ -35,7 +35,7 @@ def new_menu(request):
     menu_form = Menu()
     categories_menu_formset = inlineformset_factory(
         Menu, MenuCategory,
-        form=MenuCategoriesForm, extra=10, max_num=10
+        form=MenuCategoriesForm, extra=30, max_num=30
     )
     if request.method == 'POST':
         form = MenuForm(request.POST, instance=menu_form, prefix='main')
@@ -84,7 +84,7 @@ def update_menu(request, pk):
 
     menu_categories_formset = inlineformset_factory(Menu, MenuCategory,
                                                     form=MenuCategoriesForm,
-                                                    extra=10, max_num=10,
+                                                    extra=30, max_num=30,
                                                     can_delete=True)
 
     if request.method == 'POST':


### PR DESCRIPTION
Acredito que um queryset aplicado para gerar as opções do `select` pode melhorar isso.
Por exemplo: https://simpleisbetterthancomplex.com/tutorial/2018/01/29/how-to-implement-dependent-or-chained-dropdown-list-with-django.html

This close #42