### PR TITLE
Sort products with drag and drop.

### DIFF
--- a/menus/admin.py
+++ b/menus/admin.py
@@ -9,7 +9,7 @@ class MenuCategoryInLine(admin.StackedInline):
 
 
 class MenuAdmin(admin.ModelAdmin):
-    list_display = ('name', 'restaurant')
+    list_display = ('name', 'slug', 'restaurant')
     list_filter = ('restaurant',)
     inlines = [
         MenuCategoryInLine,

--- a/products/urls.py
+++ b/products/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('new/', views.product_new, name="product_new"),
     path('update/<pk>/', views.product_update, name="product_update"),
     path('sort/', views.products_sort, name="products_sort"),
+    path('sort/<category>/', views.products_sort, name="products_sort"),
     path('save-products-ordering', views.save_new_ordering, name="save-products-ordering"),
     path('categories/', views.categories_list, name="categories_list"),
     path('category/new/', views.category_new, name="category_new"),

--- a/products/views.py
+++ b/products/views.py
@@ -59,11 +59,16 @@ def products_list(request):
 
 
 @login_required
-def products_sort(request):
-    products = Product.objects.all().order_by('order', 'category__name', 'name').filter(
-        restaurant__manager=request.user)
+def products_sort(request, category=None):
+    if category is None:
+        products = Product.objects.all().order_by('order', 'category__name', 'name').filter(
+            restaurant__manager=request.user)
+    else:
+        products = Product.objects.all().order_by('order', 'category__name', 'name').filter(
+            restaurant__manager=request.user, category=category)
 
-    context = {'products': products}
+    context = {'products': products,
+               'category': category}
     return render(request, 'products/sort_products.html', context=context)
 
 
@@ -71,7 +76,11 @@ def products_sort(request):
 @require_POST
 def save_new_ordering(request):
     ordered_ids = request.POST["ordering"]
-    print(ordered_ids.split(","))
+    category = request.POST["categoryfilter"]
+
+    if len(ordered_ids) < 1:
+        messages.success(request, "Nenhum produto para atualizar")
+        return redirect('products_sort')
 
     current_order = 10
     for lookup_id in ordered_ids.split(","):
@@ -81,7 +90,10 @@ def save_new_ordering(request):
         current_order += 10
 
     messages.success(request, "Ordem de produtos atualizada.")
-    return redirect('products_sort')
+    if category == "None":
+        return redirect('products_sort')
+
+    return redirect('products_sort', category)
 
 
 @login_required

--- a/templates/menus/new.html
+++ b/templates/menus/new.html
@@ -81,9 +81,19 @@
             {% csrf_token %}
 
             <div class="form-row">
-              <div class="form-group col-md-12">
+              <div class="form-group col-md-8">
                 <label for="id_name">Título</label>
                 {{ form.name }}
+              </div>
+              <div class="form-group col-md-2 m-auto">
+                <div class="form-check">
+                  <label class="form-check-label">
+                    {{ form.dark_mode }} Dark Mode <i class="input-helper"></i></label>
+                </div>
+              </div>
+              <div class="form-group col-md-2">
+                <label for="id_main-variations_display_style">Estilo</label>
+                {{ form.variations_display_style }}
               </div>
             </div>
 
@@ -112,9 +122,9 @@
             </div>
             <div class="row my-5">
               <div class="col-md-12" style="display: flex; justify-content: space-between;">
-{#                <button type="button" id="add-item" class="btn btn-primary">#}
-{#                  <i class="fa fa-plus"></i> Add Categoria#}
-{#                </button>#}
+                {#                <button type="button" id="add-item" class="btn btn-primary">#}
+                {#                  <i class="fa fa-plus"></i> Add Categoria#}
+                {#                </button>#}
 
                 <input type="submit" value="Salvar" class="btn btn-success">
               </div>

--- a/templates/products/list_categories.html
+++ b/templates/products/list_categories.html
@@ -5,15 +5,15 @@
 <!-- Specific CSS goes HERE -->
 {% block stylesheets %}
   <style>
-    .food-menu-item {
-      border-bottom-style: dotted;
-      border-color: gray;
-    }
+      .food-menu-item {
+          border-bottom-style: dotted;
+          border-color: gray;
+      }
 
-    .food-category-title {
-      border-bottom-style: dotted;
-      border-color: gray;
-    }
+      .food-category-title {
+          border-bottom-style: dotted;
+          border-color: gray;
+      }
   </style>
 {% endblock stylesheets %}
 
@@ -55,15 +55,13 @@
               <div class="col-lg-3 flex-row d-flex">
                 <div class="col"></div>
                 <div class='col'>
-                  {% if category.product_set.count <= 1 %}
-                    <a class="btn btn-primary my-4" href="#" role="button">
+                  <a class="btn btn-primary my-4" href="{% url 'products_sort' category.pk %}" role="button">
+                    {% if category.product_set.count <= 1 %}
                       {{ category.product_set.count }} item
-                    </a>
-                  {% else %}
-                    <a class="btn btn-primary my-4" href="#" role="button">
+                    {% else %}
                       {{ category.product_set.count }} itens
-                    </a>
-                  {% endif %}
+                    {% endif %}
+                  </a>
                 </div>
               </div>
             </div>

--- a/templates/products/sort_products.html
+++ b/templates/products/sort_products.html
@@ -74,6 +74,7 @@
           <form id="orderingForm" method="post" action="{% url 'save-products-ordering' %}">
             {% csrf_token %}
             <input type="hidden" id="orderingInput" name="ordering">
+            <input type="hidden" id="isCategoryFiltered" name="categoryfilter" value="{{ category }}">
           </form>
           <button id="saveOrdering" class="btn btn-outline-primary btn-lg float-right mr-2">Salvar ordem</button>
 


### PR DESCRIPTION
Agora é possivel ordenar os produtos por categoria.
- adicionado nova url `products/sort/<category>`
- adiciona `slug` para MenuAdmin list
- fix: Corrigido erro ao salvar novo cardápio no front

Relacionado a issue #88 e issue #93